### PR TITLE
Fix: Add RLS policies for vocabulary and related data management

### DIFF
--- a/supabase/migrations/20250625000000_add_delete_rls_policies.sql
+++ b/supabase/migrations/20250625000000_add_delete_rls_policies.sql
@@ -1,0 +1,20 @@
+-- Add RLS DELETE policy for vocabularies table
+CREATE POLICY "Users can delete their own vocabularies" ON public.vocabularies
+  FOR DELETE TO authenticated USING (auth.uid() = created_by);
+
+-- Add RLS DELETE policy for vocabulary_words table
+CREATE POLICY "Users can delete words from their own vocabularies" ON public.vocabulary_words
+  FOR DELETE TO authenticated USING (
+    EXISTS (
+      SELECT 1 FROM public.vocabularies v
+      WHERE v.id = vocabulary_id AND v.created_by = auth.uid()
+    )
+  );
+
+-- Add RLS DELETE policy for user_progress table
+CREATE POLICY "Users can delete their own progress" ON public.user_progress
+  FOR DELETE TO authenticated USING (auth.uid() = user_id);
+
+-- Add RLS DELETE policy for vocabulary_completion table
+CREATE POLICY "Users can delete their own completion records" ON public.vocabulary_completion
+  FOR DELETE TO authenticated USING (auth.uid() = user_id);


### PR DESCRIPTION
This commit introduces Row Level Security (RLS) policies for DELETE operations on the `vocabularies`, `vocabulary_words`, `user_progress`, and `vocabulary_completion` tables.

These policies ensure that users can only modify or delete data they own or are authorized to access, specifically:
- Users can delete their own vocabularies.
- Users can delete words from vocabularies they own (necessary for the edit functionality which re-adds words).
- Users can delete their own progress records (`user_progress`).
- Users can delete their own vocabulary completion records (`vocabulary_completion`).

These changes address issues where 'Edit', 'Reset progress', and 'Delete' functionalities for vocabularies might fail due to missing RLS permissions.