### PR TITLE
feat: Implement bilingual story generation and UI terminology updates

### DIFF
--- a/src/components/CreateVocabulary.tsx
+++ b/src/components/CreateVocabulary.tsx
@@ -40,8 +40,8 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
   );
   const [title, setTitle] = useState("");
   const [topic, setTopic] = useState("");
-  const [sourceLanguage, setSourceLanguage] = useState("en");
-  const [targetLanguage, setTargetLanguage] = useState("es");
+  const [languageYouKnow, setLanguageYouKnow] = useState("en"); // Renamed from sourceLanguage
+  const [languageToLearn, setLanguageToLearn] = useState("es"); // Renamed from targetLanguage
   const [isPublic, setIsPublic] = useState(false); // Added isPublic state
   const [wordPairs, setWordPairs] = useState<WordPair[]>([
     { word: "", translation: "" },
@@ -64,16 +64,16 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
 
   // Set default languages once fetched and not yet set by user
   useEffect(() => {
-    if (languages.length > 0 && sourceLanguage === "en" && targetLanguage === "es") {
+    if (languages.length > 0 && languageYouKnow === "en" && languageToLearn === "es") {
       // Basic default, consider if user has already changed them
       // This logic might need refinement if we want to preserve user's initial non-default choices
       // before languages are loaded. For now, it sets if current state is the initial default.
-      const defaultSource = languages.find(lang => lang.code === "en");
-      const defaultTarget = languages.find(lang => lang.code === "es");
-      if (defaultSource) setSourceLanguage(defaultSource.code);
-      if (defaultTarget) setTargetLanguage(defaultTarget.code);
+      const defaultLanguageYouKnow = languages.find(lang => lang.code === "en");
+      const defaultLanguageToLearn = languages.find(lang => lang.code === "es");
+      if (defaultLanguageYouKnow) setLanguageYouKnow(defaultLanguageYouKnow.code);
+      if (defaultLanguageToLearn) setLanguageToLearn(defaultLanguageToLearn.code);
     }
-  }, [languages, sourceLanguage, targetLanguage]);
+  }, [languages, languageYouKnow, languageToLearn]);
   const [aiWordCount, setAiWordCount] = useState(10);
   const [createdVocabularyId, setCreatedVocabularyId] = useState<string | null>(
     null
@@ -88,8 +88,8 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
         {
           body: {
             topic,
-            sourceLanguage,
-            targetLanguage,
+            languageYouKnow,
+            languageToLearn,
             wordCount: aiWordCount,
           },
         }
@@ -125,8 +125,8 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
         .insert({
           title,
           topic,
-          source_language: sourceLanguage,
-          target_language: targetLanguage,
+          source_language: languageYouKnow, // DB column name is still source_language
+          target_language: languageToLearn, // DB column name is still target_language
           created_by: user.id,
           cover_image_url: vocabularyImageUrl || null, // Use the image URL if available
           is_public: isPublic, // Added is_public field
@@ -360,17 +360,17 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Source Language</Label>
+                  <Label>Language you know</Label>
                   <Select
-                    value={sourceLanguage}
-                    onValueChange={setSourceLanguage}
+                    value={languageYouKnow}
+                    onValueChange={setLanguageYouKnow}
                     disabled={createVocabularyMutation.isPending || languagesLoading}
                   >
                     <SelectTrigger>
                       {languagesLoading ? (
                         <Loader2 className="h-4 w-4 animate-spin mr-2" />
                       ) : (
-                        <SelectValue placeholder="Select source language" />
+                        <SelectValue placeholder="Select language you know" />
                       )}
                     </SelectTrigger>
                     <SelectContent>
@@ -387,17 +387,17 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
                   </Select>
                 </div>
                 <div className="space-y-2">
-                  <Label>Target Language</Label>
+                  <Label>Language to learn</Label>
                   <Select
-                    value={targetLanguage}
-                    onValueChange={setTargetLanguage}
+                    value={languageToLearn}
+                    onValueChange={setLanguageToLearn}
                     disabled={createVocabularyMutation.isPending || languagesLoading}
                   >
                     <SelectTrigger>
                       {languagesLoading ? (
                         <Loader2 className="h-4 w-4 animate-spin mr-2" />
                       ) : (
-                        <SelectValue placeholder="Select target language" />
+                        <SelectValue placeholder="Select language to learn" />
                       )}
                     </SelectTrigger>
                     <SelectContent>

--- a/src/components/LearningInterface.tsx
+++ b/src/components/LearningInterface.tsx
@@ -389,11 +389,10 @@ const LearningInterface = ({
     let urlToPlay = currentWord.audio_url;
     try {
       if (!urlToPlay) {
-        // Get source language from vocabulary details (assuming it's available or can be fetched)
-        // For this example, I'll hardcode 'en-US'. You might need to fetch vocabulary details.
+        // Get languageYouKnow from vocabulary details
         const { data: vocabularyData, error: vocabError } = await supabase
           .from("vocabularies")
-          .select("source_language")
+          .select("source_language") // Still 'source_language' in DB
           .eq("id", vocabularyId)
           .single();
 

--- a/src/components/PlayStoryInterface.tsx
+++ b/src/components/PlayStoryInterface.tsx
@@ -190,9 +190,18 @@ const PlayStoryInterface: React.FC<PlayStoryInterfaceProps> = ({
                     </span>
                   )}
                 </p>
-                <p className="text-lg text-gray-700 leading-relaxed">
+                <p className="text-lg text-gray-700 leading-relaxed mb-2"> {/* mb-2 to add space before the next language bit */}
                   {renderDescriptionWithBoldWord(currentBit.sentence, currentBit.word)}
                 </p>
+                {currentBit.sentence_language_you_know && (
+                  <div className="mt-4 pt-4 border-t border-gray-200">
+                    <p className="text-sm text-gray-500 mb-1">In language you know:</p> {/* Simple label */}
+                    <p className="text-md text-gray-600 leading-relaxed">
+                      {/* We might not need to bold the word here, or use its translation if available */}
+                      {renderDescriptionWithBoldWord(currentBit.sentence_language_you_know, currentBit.word)}
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/src/lib/geminiUtils.ts
+++ b/src/lib/geminiUtils.ts
@@ -9,7 +9,8 @@ interface WordDetail {
 
 export interface GeminiStoryBit {
   word: string;
-  storyBitDescription: string;
+  storyBitDescription: string; // In languageToLearn
+  storyBitDescriptionInLanguageYouKnow: string; // In languageYouKnow
   imagePrompt: string;
 }
 
@@ -24,8 +25,8 @@ export class GeminiGenerationError extends Error {
 export const generateStoryFromWords = async (
   words: WordDetail[],
   vocabularyTitle: string,
-  sourceLanguage: string,
-  targetLanguage: string
+  languageYouKnow: string,
+  languageToLearn: string
 ): Promise<GeminiStoryBit[]> => {
   if (!words || words.length === 0) {
     throw new GeminiGenerationError("No words provided to generate a story.");
@@ -34,8 +35,8 @@ export const generateStoryFromWords = async (
   const payload = {
     words,
     vocabularyTitle,
-    sourceLanguage,
-    targetLanguage,
+    languageYouKnow, // Updated parameter name
+    languageToLearn, // Updated parameter name
   };
 
   try {
@@ -74,9 +75,14 @@ export const generateStoryFromWords = async (
       );
     }
     data.forEach((bit, index) => {
-      if (!bit.word || !bit.storyBitDescription || !bit.imagePrompt) {
+      if (
+        !bit.word ||
+        !bit.storyBitDescription ||
+        !bit.storyBitDescriptionInLanguageYouKnow || // Check for the new field
+        !bit.imagePrompt
+      ) {
         throw new GeminiGenerationError(
-          `Story bit ${index} from service is missing one or more required fields (word, storyBitDescription, imagePrompt). Bit: ${JSON.stringify(bit)}`
+          `Story bit ${index} from service is missing one or more required fields (word, storyBitDescription, storyBitDescriptionInLanguageYouKnow, imagePrompt). Bit: ${JSON.stringify(bit)}` // Updated error message
         );
       }
     });

--- a/supabase/migrations/$(date +%Y%m%d%H%M%S)_add_sentence_language_you_know_to_story_bits.sql
+++ b/supabase/migrations/$(date +%Y%m%d%H%M%S)_add_sentence_language_you_know_to_story_bits.sql
@@ -1,0 +1,58 @@
+-- Add the new column to the story_bits table
+ALTER TABLE public.story_bits
+ADD COLUMN sentence_language_you_know TEXT;
+
+-- Optional: Add a comment to describe the new column
+COMMENT ON COLUMN public.story_bits.sentence_language_you_know IS 'Stores the story sentence/bit in the language the user already knows, complementing the existing sentence column which is in the language to learn.';
+
+-- Update RLS policies if necessary.
+-- If you have row-level security policies on story_bits that specify columns,
+-- you might need to update them to include the new column if it should be accessible.
+-- For example, if you have a policy like:
+-- CREATE POLICY "Users can read their own story bits"
+-- ON public.story_bits
+-- FOR SELECT USING (auth.uid() = user_id);
+-- And you want the new column to be selectable, this policy might already cover it
+-- if it doesn't explicitly list columns. If it does list columns, add
+-- sentence_language_you_know to the list.
+
+-- For now, assuming existing policies are permissive enough or column-specific policies
+-- will be updated manually if strict column controls are in place.
+-- If INSERT policies specify columns, they also might need an update if all columns must be listed.
+-- However, standard INSERTs where not all columns are provided (and others get defaults or NULL)
+-- usually don't require policy changes for adding a nullable column.
+
+-- Example of how you might update a policy if it explicitly listed columns for SELECT:
+-- DROP POLICY "Users can read their own story bits" ON public.story_bits;
+-- CREATE POLICY "Users can read their own story bits"
+-- ON public.story_bits
+-- FOR SELECT USING (auth.uid() = user_id)
+-- WITH CHECK (auth.uid() = user_id); -- Assuming it was also for all operations or specific ones.
+
+-- For INSERT, if it was specific:
+-- DROP POLICY "Users can insert their own story bits" ON public.story_bits;
+-- CREATE POLICY "Users can insert their own story bits"
+-- ON public.story_bits
+-- FOR INSERT
+-- WITH CHECK (
+--   auth.uid() = user_id AND
+--   -- if you had to list columns, ensure the new one is allowed or handled by default
+-- );
+
+-- Since the new column is nullable, existing INSERT operations that don't specify
+-- this new column will work by defaulting it to NULL, which is acceptable.
+-- SELECT policies that don't list columns (e.g., SELECT * ...) will automatically include it.
+-- If policies are more restrictive (e.g., SELECT col1, col2 FROM ...), they'll need manual updates.
+-- Given typical Supabase RLS, often policies are not column-specific unless for security redaction.
+-- So, no RLS changes are made automatically here, but noted for consideration.
+
+-- It's also good practice to ensure that any services/roles that interact with this table
+-- have the necessary permissions for the new column.
+-- For example, the 'service_role' and 'authenticated' roles.
+-- GRANT SELECT ON public.story_bits TO authenticated;
+-- GRANT INSERT (sentence_language_you_know) ON public.story_bits TO authenticated; -- if needed explicitly.
+-- Typically, Supabase default grants are sufficient.
+-- GRANT ALL ON TABLE public.story_bits TO service_role;
+-- These are usually already in place.
+
+SELECT 'Migration to add sentence_language_you_know to story_bits complete.';


### PR DESCRIPTION
- Update Edge Function `generate-story-with-gemini` to accept `languageYouKnow` and `languageToLearn` and to return story bits in both languages.
- Update `storyUtils.ts` and `geminiUtils.ts` to handle bilingual story generation, including saving the new `sentence_language_you_know` to the `story_bits` table.
- Add `sentence_language_you_know` column to `story_bits` table via migration (migration file created earlier).
- Update `PlayStoryInterface.tsx` to display story bits in both languages.
- Add "Re-generate Story" functionality to `EditVocabulary.tsx`, including deletion of the old story.
- Globally replace UI terminology from "Source/Target Language" to "Language you know/Language to learn" in `CreateVocabulary.tsx`, `EditVocabulary.tsx`, and relevant comments.
- Database column names `source_language` and `target_language` in the `vocabularies` table remain unchanged as per user request, with mapping handled in the application code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking vocabularies as public or private.
  * Introduced the ability to re-generate stories for existing vocabularies with clear UI feedback.
  * Story bits now display both the sentence in the language to learn and its translation in the language you know.

* **Improvements**
  * Updated language selection labels to "Language you know" and "Language to learn" for greater clarity.
  * Enhanced story generation to include both target and known language descriptions for each story bit.

* **Bug Fixes**
  * Improved validation and error messages for story generation and vocabulary management.

* **Documentation**
  * Refined comments for better clarity regarding language handling and database fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->