### PR TITLE
Fix: Preserve cover_image_url on vocabulary edit

### DIFF
--- a/src/components/EditVocabulary.tsx
+++ b/src/components/EditVocabulary.tsx
@@ -113,6 +113,7 @@ const EditVocabulary = ({ vocabularyId, onBack }: EditVocabularyProps) => {
       setLanguageToLearn(vocabularyData.target_language); // DB field is target_language
       setIsPublic(vocabularyData.is_public || false); // Set isPublic from fetched data
       setStoryId(vocabularyData.stories?.[0]?.id || null);
+      setVocabularyImageUrl(vocabularyData.cover_image_url || null);
     }
   }, [vocabularyData]);
 


### PR DESCRIPTION
The cover_image_url was being reset to null during vocabulary updates because the corresponding state variable in EditVocabulary.tsx was not initialized with the existing URL from the database.

This commit initializes the `vocabularyImageUrl` state with the fetched `cover_image_url`, ensuring it's preserved unless a new image is explicitly generated via the AI feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the vocabulary cover image was not properly displayed when editing vocabulary entries. The cover image now loads correctly from saved data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->