### PR TITLE
Fix: Improve language selection and default handling in vocabulary cr…

### DIFF
--- a/src/components/CreateVocabulary.tsx
+++ b/src/components/CreateVocabulary.tsx
@@ -62,35 +62,33 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
     }
   }, [fetchLanguages, languagesHasFetched]);
 
-  // Set default languages once fetched and not yet set by user
+  // Effect to set default for languageYouKnow
   useEffect(() => {
-    if (languages.length > 0) {
-      let currentKnowLangCode: string | undefined = languageYouKnow;
-
-      if (currentKnowLangCode === undefined) {
-        const defaultUserLang = languages.find(lang => lang.code === "en") || languages[0];
-        if (defaultUserLang) {
-          setLanguageYouKnow(defaultUserLang.code);
-          currentKnowLangCode = defaultUserLang.code; // Update for use in LTL logic immediately
-        }
-      }
-
-      if (languageToLearn === undefined) {
-        const preferredLearnLang = languages.find(lang => lang.code === "es");
-        if (preferredLearnLang && preferredLearnLang.code !== currentKnowLangCode) {
-          setLanguageToLearn(preferredLearnLang.code);
-        } else {
-          // Find first available language that is not currentKnowLangCode
-          const fallbackLearnLang = languages.find(lang => lang.code !== currentKnowLangCode);
-          if (fallbackLearnLang) {
-            setLanguageToLearn(fallbackLearnLang.code);
-          }
-          // If no suitable fallback is found, languageToLearn remains undefined.
-          // Validation prior to submission will handle this.
-        }
+    if (languages.length > 0 && languageYouKnow === undefined) {
+      const defaultUserLang = languages.find(lang => lang.code === "en") || languages[0];
+      if (defaultUserLang) {
+        setLanguageYouKnow(defaultUserLang.code);
       }
     }
-  }, [languages, languageYouKnow]); // languageYouKnow is needed as its update affects languageToLearn default.
+  }, [languages]); // Only depends on languages
+
+  // Effect to set default for languageToLearn
+  useEffect(() => {
+    if (languages.length > 0 && languageYouKnow && languageToLearn === undefined) {
+      const preferredLearnLang = languages.find(lang => lang.code === "es");
+      if (preferredLearnLang && preferredLearnLang.code !== languageYouKnow) {
+        setLanguageToLearn(preferredLearnLang.code);
+      } else {
+        // Find first available language that is not languageYouKnow
+        const fallbackLearnLang = languages.find(lang => lang.code !== languageYouKnow);
+        if (fallbackLearnLang) {
+          setLanguageToLearn(fallbackLearnLang.code);
+        }
+        // If no suitable fallback is found, languageToLearn remains undefined.
+        // Validation prior to submission will handle this.
+      }
+    }
+  }, [languages, languageYouKnow, languageToLearn]); // Depends on languages, languageYouKnow, and languageToLearn (to check if it's undefined)
 
   const [aiWordCount, setAiWordCount] = useState(10);
   const [createdVocabularyId, setCreatedVocabularyId] = useState<string | null>(

--- a/src/components/CreateVocabulary.tsx
+++ b/src/components/CreateVocabulary.tsx
@@ -40,8 +40,8 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
   );
   const [title, setTitle] = useState("");
   const [topic, setTopic] = useState("");
-  const [languageYouKnow, setLanguageYouKnow] = useState("en"); // Renamed from sourceLanguage
-  const [languageToLearn, setLanguageToLearn] = useState("es"); // Renamed from targetLanguage
+  const [languageYouKnow, setLanguageYouKnow] = useState<string | undefined>(undefined); // Renamed from sourceLanguage
+  const [languageToLearn, setLanguageToLearn] = useState<string | undefined>(undefined); // Renamed from targetLanguage
   const [isPublic, setIsPublic] = useState(false); // Added isPublic state
   const [wordPairs, setWordPairs] = useState<WordPair[]>([
     { word: "", translation: "" },
@@ -64,16 +64,34 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
 
   // Set default languages once fetched and not yet set by user
   useEffect(() => {
-    if (languages.length > 0 && languageYouKnow === "en" && languageToLearn === "es") {
-      // Basic default, consider if user has already changed them
-      // This logic might need refinement if we want to preserve user's initial non-default choices
-      // before languages are loaded. For now, it sets if current state is the initial default.
-      const defaultLanguageYouKnow = languages.find(lang => lang.code === "en");
-      const defaultLanguageToLearn = languages.find(lang => lang.code === "es");
-      if (defaultLanguageYouKnow) setLanguageYouKnow(defaultLanguageYouKnow.code);
-      if (defaultLanguageToLearn) setLanguageToLearn(defaultLanguageToLearn.code);
+    if (languages.length > 0) {
+      let currentKnowLangCode: string | undefined = languageYouKnow;
+
+      if (currentKnowLangCode === undefined) {
+        const defaultUserLang = languages.find(lang => lang.code === "en") || languages[0];
+        if (defaultUserLang) {
+          setLanguageYouKnow(defaultUserLang.code);
+          currentKnowLangCode = defaultUserLang.code; // Update for use in LTL logic immediately
+        }
+      }
+
+      if (languageToLearn === undefined) {
+        const preferredLearnLang = languages.find(lang => lang.code === "es");
+        if (preferredLearnLang && preferredLearnLang.code !== currentKnowLangCode) {
+          setLanguageToLearn(preferredLearnLang.code);
+        } else {
+          // Find first available language that is not currentKnowLangCode
+          const fallbackLearnLang = languages.find(lang => lang.code !== currentKnowLangCode);
+          if (fallbackLearnLang) {
+            setLanguageToLearn(fallbackLearnLang.code);
+          }
+          // If no suitable fallback is found, languageToLearn remains undefined.
+          // Validation prior to submission will handle this.
+        }
+      }
     }
-  }, [languages, languageYouKnow, languageToLearn]);
+  }, [languages, languageYouKnow]); // languageYouKnow is needed as its update affects languageToLearn default.
+
   const [aiWordCount, setAiWordCount] = useState(10);
   const [createdVocabularyId, setCreatedVocabularyId] = useState<string | null>(
     null
@@ -186,6 +204,22 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
       });
       return;
     }
+    if (!languageYouKnow || !languageToLearn) {
+      toast({
+        title: "Error",
+        description: "Please select both 'Language you know' and 'Language to learn'.",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (languageYouKnow === languageToLearn) {
+      toast({
+        title: "Error",
+        description: "'Language you know' and 'Language to learn' must be different.",
+        variant: "destructive",
+      });
+      return;
+    }
     generateVocabularyMutation.mutate();
   };
 
@@ -216,6 +250,24 @@ const CreateVocabulary = ({ onBack }: CreateVocabularyProps) => {
       toast({
         title: "Error",
         description: "Please fill in the title and topic.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!languageYouKnow || !languageToLearn) {
+      toast({
+        title: "Error",
+        description: "Please select both 'Language you know' and 'Language to learn'.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (languageYouKnow === languageToLearn) {
+      toast({
+        title: "Error",
+        description: "'Language you know' and 'Language to learn' must be different.",
         variant: "destructive",
       });
       return;


### PR DESCRIPTION
…eation

- Initialize languageYouKnow and languageToLearn states to undefined.
- Modify useEffect to set default languages ('en', 'es' if available and distinct, or fallbacks) only when languages are loaded and states are undefined.
- Added validation to ensure both languages are selected and are different before AI generation or saving vocabulary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of default language selections to prevent unintended defaults.
  * Enhanced validation to ensure both languages are selected and are not the same before generating vocabulary or submitting the form.
  * Added clear error messages when language selections are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->