### PR TITLE
feat: Enhance story creation and playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite_react_shadcn_ts",
-  "version": "0.1.7",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite_react_shadcn_ts",
-      "version": "0.1.7",
+      "version": "0.1.11",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@hookform/resolvers": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/CreateVocabulary.tsx
+++ b/src/components/CreateVocabulary.tsx
@@ -438,8 +438,9 @@ const CreateVocabulary = ({
       } else {
         toast({
           title: "Story Creation Failed",
-          description: "An unexpected error occurred.",
+          description: "An unexpected error occurred. AI is not stable. Try one more time.",
           variant: "destructive",
+          duration: 10000,
         });
       }
       console.error("Story generation failed:", error);
@@ -721,8 +722,16 @@ const CreateVocabulary = ({
                 >
                   Start Learning
                 </Button>
-
-                {storyCreated && createdStoryId ? (
+                <Button
+                  onClick={handleCreateStory}
+                  variant="outline"
+                  className="w-full md:w-auto"
+                  disabled={isCreatingStory}
+                >
+                  <BookPlus className="h-4 w-4 mr-2" />
+                  {isCreatingStory ? "Creating Story..." : "Create Story"}
+                </Button>
+                {storyCreated && createdStoryId && (
                   <Button
                     onClick={() =>
                       onPlayStory(createdVocabularyId, title, createdStoryId)
@@ -731,16 +740,6 @@ const CreateVocabulary = ({
                     className="w-full md:w-auto"
                   >
                     Play Story
-                  </Button>
-                ) : (
-                  <Button
-                    onClick={handleCreateStory}
-                    variant="outline"
-                    className="w-full md:w-auto"
-                    disabled={isCreatingStory}
-                  >
-                    <BookPlus className="h-4 w-4 mr-2" />
-                    {isCreatingStory ? "Creating Story..." : "Create Story"}
                   </Button>
                 )}
               </div>

--- a/src/components/PlayStoryInterface.tsx
+++ b/src/components/PlayStoryInterface.tsx
@@ -31,12 +31,14 @@ interface PlayStoryInterfaceProps {
   storyId: string;
   vocabularyTitle: string;
   onBack: () => void;
+  onStartLearning: (vocabularyId: string, vocabularyTitle: string) => void;
 }
 
 const PlayStoryInterface: React.FC<PlayStoryInterfaceProps> = ({
   storyId,
   vocabularyTitle, // This might become redundant if fetched with story details, but keep for now
   onBack,
+  onStartLearning,
 }) => {
   const queryClient = useQueryClient();
   const [currentBitIndex, setCurrentBitIndex] = useState(0);
@@ -402,15 +404,24 @@ const PlayStoryInterface: React.FC<PlayStoryInterfaceProps> = ({
               {/* Page counter */}
               {currentBitIndex + 1} of {storyBits.length}
             </div>
-            <Button
-              onClick={handleNext}
-              disabled={currentBitIndex === storyBits.length - 1}
-              variant="outline"
-              className="flex-1" // Allow button to grow
-            >
-              Next
-              <ChevronRight className="ml-2 h-4 w-4" />
-            </Button>
+            {currentBitIndex === storyBits.length - 1 ? (
+              <Button
+                onClick={() => onStartLearning(vocabularyId!, vocabularyTitle)}
+                className="flex-1"
+              >
+                Learn
+              </Button>
+            ) : (
+              <Button
+                onClick={handleNext}
+                disabled={currentBitIndex === storyBits.length - 1}
+                variant="outline"
+                className="flex-1" // Allow button to grow
+              >
+                Next
+                <ChevronRight className="ml-2 h-4 w-4" />
+              </Button>
+            )}
           </div>
           <Button
             onClick={handleRestart}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -151,6 +151,7 @@ const Dashboard = () => {
               storyId={selectedInfo.storyId}
               vocabularyTitle={selectedInfo.title}
               onBack={handleBackToList}
+              onStartLearning={handleStartLearning}
             />
           )}
       </main>

--- a/supabase/functions/generate-story-with-gemini/index.ts
+++ b/supabase/functions/generate-story-with-gemini/index.ts
@@ -139,6 +139,7 @@ serve(async (req: Request) => {
       The story must be broken down into several "bits" or parts. Each bit must prominently feature one of the provided vocabulary words.
       The number of story bits must be exactly equal to the number of words provided (${words.length} words = ${words.length} bits).
       The story bits must flow logically and form a single, connected narrative.
+      The story should follow the classic hero's journey archetype.
 
       For each story bit, you must provide:
       1.  "word": The specific vocabulary word (from the provided list, in ${languageYouKnow}) that is central to this bit.


### PR DESCRIPTION
This commit introduces several improvements to the story creation and playback features:

- Adds a 'Play Story' button on the story creation page, which appears next to the 'Create Story' button after a story has been generated.
- Increases the duration of the error toast message for story creation to 10 seconds and adds a message about AI instability.
- Modifies the story generation prompt to include a requirement for the story to follow the classic hero's journey archetype.
- Adds a 'Learn' button at the end of the story playback, which allows the user to start a learning session for the vocabulary associated with the story.