### PR TITLE
feat: Add bulk actions to vocabulary management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite_react_shadcn_ts",
-  "version": "0.1.135",
+  "version": "0.1.142",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite_react_shadcn_ts",
-      "version": "0.1.135",
+      "version": "0.1.142",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@hookform/resolvers": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.135",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/CreateVocabulary.tsx
+++ b/src/components/CreateVocabulary.tsx
@@ -848,13 +848,15 @@ const CreateVocabulary = ({
                       <Checkbox
                         checked={selectedWordIndexes.has(index)}
                         onCheckedChange={(checked) => {
-                          const newSet = new Set(selectedWordIndexes);
-                          if (checked) {
-                            newSet.add(index);
-                          } else {
-                            newSet.delete(index);
-                          }
-                          setSelectedWordIndexes(newSet);
+                          setSelectedWordIndexes((prev) => {
+                            const newSet = new Set(prev);
+                            if (checked) {
+                              newSet.add(index);
+                            } else {
+                              newSet.delete(index);
+                            }
+                            return newSet;
+                          });
                         }}
                       />
                       <Input

--- a/src/components/CreateVocabulary.tsx
+++ b/src/components/CreateVocabulary.tsx
@@ -436,8 +436,14 @@ const CreateVocabulary = ({
     if (wordPairs.length > 1) {
       setWordPairs(wordPairs.filter((_, i) => i !== index));
       setSelectedWordIndexes((prev) => {
-        const newSet = new Set(prev);
-        newSet.delete(index);
+        const newSet = new Set<number>();
+        prev.forEach((selectedIndex) => {
+          if (selectedIndex < index) {
+            newSet.add(selectedIndex);
+          } else if (selectedIndex > index) {
+            newSet.add(selectedIndex - 1);
+          }
+        });
         return newSet;
       });
     }

--- a/src/components/CreateVocabulary.tsx
+++ b/src/components/CreateVocabulary.tsx
@@ -38,6 +38,7 @@ import { useLanguageStore } from "@/stores/languageStore"; // Import the languag
 import { useEffect } from "react"; // Import useEffect
 import { useToast } from "@/hooks/use-toast";
 import { generateAndSaveStory, StoryGenerationError } from "@/lib/storyUtils"; // Added
+import { Checkbox } from "@/components/ui/checkbox";
 
 const STORY_CREATION_ERROR_TOAST_DURATION = 10000;
 
@@ -76,6 +77,9 @@ const CreateVocabulary = ({
   const [wordPairs, setWordPairs] = useState<WordPair[]>([
     { word: "", translation: "" },
   ]);
+  const [selectedWordIndexes, setSelectedWordIndexes] = useState<Set<number>>(
+    new Set()
+  );
   const [showConfirmation, setShowConfirmation] = useState(false);
 
   // Language store integration
@@ -431,6 +435,40 @@ const CreateVocabulary = ({
   const removeWordPair = (index: number) => {
     if (wordPairs.length > 1) {
       setWordPairs(wordPairs.filter((_, i) => i !== index));
+      setSelectedWordIndexes((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(index);
+        return newSet;
+      });
+    }
+  };
+
+  const handleDeleteSelected = () => {
+    if (selectedWordIndexes.size === 0) {
+      return;
+    }
+    const newWordPairs = wordPairs.filter(
+      (_, index) => !selectedWordIndexes.has(index)
+    );
+    setWordPairs(newWordPairs.length > 0 ? newWordPairs : [{ word: "", translation: "" }]);
+    setSelectedWordIndexes(new Set());
+  };
+
+  const handleTranslateSelected = () => {
+    if (selectedWordIndexes.size === 0) {
+      return;
+    }
+    selectedWordIndexes.forEach((index) => {
+      handleTranslateWord(index);
+    });
+  };
+
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      const allIndexes = new Set(wordPairs.map((_, index) => index));
+      setSelectedWordIndexes(allIndexes);
+    } else {
+      setSelectedWordIndexes(new Set());
     }
   };
 
@@ -756,9 +794,63 @@ const CreateVocabulary = ({
                   data-testid="file-import-input"
                 />
 
+                <div className="flex items-center justify-between mt-4">
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="select-all"
+                      checked={
+                        selectedWordIndexes.size > 0 &&
+                        selectedWordIndexes.size === wordPairs.length
+                          ? true
+                          : selectedWordIndexes.size > 0
+                          ? "indeterminate"
+                          : false
+                      }
+                      onCheckedChange={(checked) =>
+                        handleSelectAll(checked as boolean)
+                      }
+                    />
+                    <Label htmlFor="select-all">Select All</Label>
+                  </div>
+                  <div className="flex space-x-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={handleDeleteSelected}
+                      disabled={selectedWordIndexes.size === 0}
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Delete Selected
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={handleTranslateSelected}
+                      disabled={selectedWordIndexes.size === 0}
+                    >
+                      <Languages className="h-4 w-4 mr-2" />
+                      Translate Selected
+                    </Button>
+                  </div>
+                </div>
+
                 <div className="space-y-3 max-h-60 overflow-y-auto pr-2">
                   {wordPairs.map((pair, index) => (
                     <div key={index} className="flex space-x-2 items-center">
+                      <Checkbox
+                        checked={selectedWordIndexes.has(index)}
+                        onCheckedChange={(checked) => {
+                          const newSet = new Set(selectedWordIndexes);
+                          if (checked) {
+                            newSet.add(index);
+                          } else {
+                            newSet.delete(index);
+                          }
+                          setSelectedWordIndexes(newSet);
+                        }}
+                      />
                       <Input
                         placeholder="Word"
                         value={pair.word}


### PR DESCRIPTION
Adds bulk actions (delete, translate) to the "Create vocabulary" and "Edit vocabulary" pages.

This includes:
- Checkboxes for each word row.
- A "select all" checkbox at the top of the word list.
- "Delete" and "Translate" buttons that are enabled when at least one word is selected.
- The "select all" checkbox has an indeterminate state when some, but not all, words are selected.
- Unit tests for the new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Select multiple word pairs with per-row checkboxes and a tri-state “Select All.”
  * Bulk actions: Delete Selected and Translate Selected, with disabled states when nothing is selected.
  * Create and re-generate stories from a vocabulary with clear success/error feedback; cover image and story status reflected in UI.
  * Public/private toggle for vocabularies.

* Tests
  * Added suites validating selection, “Select All” indeterminate state, bulk delete/translate, and translation targeting in create/edit views.

* Chores
  * Version updated to 0.1.142.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->